### PR TITLE
Integration with ckanext-disqus with ability to disable comments per story 

### DIFF
--- a/ckanext/showcase/controller.py
+++ b/ckanext/showcase/controller.py
@@ -54,9 +54,6 @@ class ShowcaseController(PackageController):
         except NotAuthorized:
             abort(401, _('Unauthorized to create a package'))
 
-        # get discuss name
-        c.disqus_name = config.get('disqus.name')
-
         return super(ShowcaseController, self).new(data=data, errors=errors,
                                                    error_summary=error_summary)
 
@@ -72,9 +69,6 @@ class ShowcaseController(PackageController):
         except NotAuthorized:
             abort(401, _('User not authorized to edit {showcase_id}').format(
                 showcase_id=id))
-
-        # get discuss name
-        c.disqus_name = config.get('disqus.name')
 
         return super(ShowcaseController, self).edit(
             id, data=data, errors=errors, error_summary=error_summary)
@@ -155,9 +149,6 @@ class ShowcaseController(PackageController):
         # get showcase packages
         c.showcase_pkgs = get_action('ckanext_showcase_package_list')(
             context, {'showcase_id': c.pkg_dict['id']})
-
-        # get discuss name
-        c.disqus_name = config.get('disqus.name')
 
         package_type = DATASET_TYPE_NAME
         return render(self._read_template(package_type),

--- a/ckanext/showcase/controller.py
+++ b/ckanext/showcase/controller.py
@@ -54,6 +54,9 @@ class ShowcaseController(PackageController):
         except NotAuthorized:
             abort(401, _('Unauthorized to create a package'))
 
+        # get discuss name
+        c.disqus_name = config.get('disqus.name')
+
         return super(ShowcaseController, self).new(data=data, errors=errors,
                                                    error_summary=error_summary)
 
@@ -69,6 +72,9 @@ class ShowcaseController(PackageController):
         except NotAuthorized:
             abort(401, _('User not authorized to edit {showcase_id}').format(
                 showcase_id=id))
+
+        # get discuss name
+        c.disqus_name = config.get('disqus.name')
 
         return super(ShowcaseController, self).edit(
             id, data=data, errors=errors, error_summary=error_summary)
@@ -149,6 +155,9 @@ class ShowcaseController(PackageController):
         # get showcase packages
         c.showcase_pkgs = get_action('ckanext_showcase_package_list')(
             context, {'showcase_id': c.pkg_dict['id']})
+
+        # get discuss name
+        c.disqus_name = config.get('disqus.name')
 
         package_type = DATASET_TYPE_NAME
         return render(self._read_template(package_type),

--- a/ckanext/showcase/logic/helpers.py
+++ b/ckanext/showcase/logic/helpers.py
@@ -1,6 +1,7 @@
 import re
 import logging
 import ckan.lib.helpers as h
+from ckan.common import config
 from ckan.plugins import toolkit as tk
 log = logging.getLogger(__name__)
 
@@ -32,6 +33,10 @@ def get_site_statistics():
         tk.get_action('organization_list')({}, {}))
 
     return stats
+
+
+def is_disqus_enabled():
+    return bool(config.get('disqus.name'))
 
 
 def search_emdedded_elements(text):

--- a/ckanext/showcase/logic/schema.py
+++ b/ckanext/showcase/logic/schema.py
@@ -1,4 +1,6 @@
+import logging
 import ckan.plugins.toolkit as toolkit
+from ckan.common import config
 from ckan.lib.navl.validators import (not_empty,
                                       empty,
                                       if_empty_same_as,
@@ -19,6 +21,8 @@ from ckan.logic.schema import (default_tags_schema,
 from ckanext.showcase.logic.validators import (
     convert_package_name_or_id_to_id_for_type_dataset,
     convert_package_name_or_id_to_id_for_type_showcase)
+
+log = logging.getLogger(__name__)
 
 
 def showcase_base_schema():
@@ -42,16 +46,23 @@ def showcase_base_schema():
         'extras': default_extras_schema(),
         'save': [ignore],
         'return_to': [ignore],
-        'image_url': [toolkit.get_validator('ignore_missing'),
-                      toolkit.get_converter('convert_to_extras')],
-        'original_related_item_id': [
-            toolkit.get_validator('ignore_missing'),
-            toolkit.get_converter('convert_to_extras')],
-        'allow_commenting': [
+    }
+
+    # Extras
+    schema['image_url'] = [
+        toolkit.get_validator('ignore_missing'),
+        toolkit.get_converter('convert_to_extras')]
+    schema['original_related_item_id'] = [
+        toolkit.get_validator('ignore_missing'),
+        toolkit.get_converter('convert_to_extras')]
+
+    # Extras (conditional)
+    if config.get('disqus.name'):
+        schema['allow_commenting'] = [
             toolkit.get_validator('ignore_missing'),
             toolkit.get_validator('boolean_validator'),
-            toolkit.get_converter('convert_to_extras')],
-    }
+            toolkit.get_converter('convert_to_extras')]
+
     return schema
 
 
@@ -107,17 +118,20 @@ def showcase_show_schema():
     schema['revision_id'] = []
     schema['tracking_summary'] = []
 
-    schema.update({
-        'image_url': [toolkit.get_converter('convert_from_extras'),
-                      toolkit.get_validator('ignore_missing')],
-        'original_related_item_id': [
-            toolkit.get_converter('convert_from_extras'),
-            toolkit.get_validator('ignore_missing')],
-        'allow_commenting': [
+    # Extras
+    schema['image_url'] = [
+        toolkit.get_converter('convert_from_extras'),
+        toolkit.get_validator('ignore_missing')]
+    schema['original_related_item_id'] = [
+        toolkit.get_converter('convert_from_extras'),
+        toolkit.get_validator('ignore_missing')]
+
+    # Extras (conditional)
+    if config.get('disqus.name'):
+        schema['allow_commenting'] = [
             toolkit.get_converter('convert_from_extras'),
             toolkit.get_validator('boolean_validator'),
-            toolkit.get_validator('ignore_missing')],
-    })
+            toolkit.get_validator('ignore_missing')]
 
     return schema
 

--- a/ckanext/showcase/logic/schema.py
+++ b/ckanext/showcase/logic/schema.py
@@ -11,8 +11,7 @@ from ckan.logic.validators import (package_id_not_changed,
                                    package_name_validator,
                                    tag_string_convert,
                                    ignore_not_package_admin,
-                                   no_http,
-                                   boolean_validator)
+                                   no_http)
 from ckan.logic.schema import (default_tags_schema,
                                default_extras_schema,
                                default_resource_schema)
@@ -30,7 +29,6 @@ def showcase_base_schema():
         'title': [if_empty_same_as("name"), unicode],
         'author': [ignore_missing, unicode],
         'author_email': [ignore_missing, unicode],
-        'allow_commenting': [unicode],
         'notes': [ignore_missing, unicode],
         'url': [ignore_missing, unicode],
         'state': [ignore_not_package_admin, ignore_missing],
@@ -48,7 +46,11 @@ def showcase_base_schema():
                       toolkit.get_converter('convert_to_extras')],
         'original_related_item_id': [
             toolkit.get_validator('ignore_missing'),
-            toolkit.get_converter('convert_to_extras')]
+            toolkit.get_converter('convert_to_extras')],
+        'allow_commenting': [
+            toolkit.get_validator('ignore_missing'),
+            toolkit.get_validator('boolean_validator'),
+            toolkit.get_converter('convert_to_extras')],
     }
     return schema
 
@@ -93,7 +95,6 @@ def showcase_show_schema():
     # None).
     schema['author'] = []
     schema['author_email'] = []
-    schema['allow_commenting'] = []
     schema['notes'] = []
     schema['url'] = []
 
@@ -111,7 +112,11 @@ def showcase_show_schema():
                       toolkit.get_validator('ignore_missing')],
         'original_related_item_id': [
             toolkit.get_converter('convert_from_extras'),
-            toolkit.get_validator('ignore_missing')]
+            toolkit.get_validator('ignore_missing')],
+        'allow_commenting': [
+            toolkit.get_converter('convert_from_extras'),
+            toolkit.get_validator('boolean_validator'),
+            toolkit.get_validator('ignore_missing')],
     })
 
     return schema

--- a/ckanext/showcase/logic/schema.py
+++ b/ckanext/showcase/logic/schema.py
@@ -11,7 +11,8 @@ from ckan.logic.validators import (package_id_not_changed,
                                    package_name_validator,
                                    tag_string_convert,
                                    ignore_not_package_admin,
-                                   no_http)
+                                   no_http,
+                                   boolean_validator)
 from ckan.logic.schema import (default_tags_schema,
                                default_extras_schema,
                                default_resource_schema)
@@ -29,6 +30,7 @@ def showcase_base_schema():
         'title': [if_empty_same_as("name"), unicode],
         'author': [ignore_missing, unicode],
         'author_email': [ignore_missing, unicode],
+        'allow_commenting': [unicode],
         'notes': [ignore_missing, unicode],
         'url': [ignore_missing, unicode],
         'state': [ignore_not_package_admin, ignore_missing],
@@ -91,6 +93,7 @@ def showcase_show_schema():
     # None).
     schema['author'] = []
     schema['author_email'] = []
+    schema['allow_commenting'] = []
     schema['notes'] = []
     schema['url'] = []
 

--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -96,7 +96,8 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
     def get_helpers(self):
         return {
             'facet_remove_field': showcase_helpers.facet_remove_field,
-            'get_site_statistics': showcase_helpers.get_site_statistics
+            'get_site_statistics': showcase_helpers.get_site_statistics,
+            'is_disqus_enabled': showcase_helpers.is_disqus_enabled,
         }
 
     # IFacets

--- a/ckanext/showcase/templates/showcase/new_package_form.html
+++ b/ckanext/showcase/templates/showcase/new_package_form.html
@@ -51,7 +51,7 @@
     {% endblock %}
 
     {% block package_metadata_allow_commenting %}
-      {% if c.disqus_name %}
+      {% if h.is_disqus_enabled() %}
         {{ form.select('allow_commenting', label='Allow commenting', id='field-allow_commenting', options=[{'text':'Yes', 'value': True},{'text': 'No', 'value': False}], selected=data.allow_commenting, error=errors.allow_commenting) }}
       {% endif %}
     {% endblock %}

--- a/ckanext/showcase/templates/showcase/new_package_form.html
+++ b/ckanext/showcase/templates/showcase/new_package_form.html
@@ -37,6 +37,7 @@
       {% set is_url = data.image_url and data.image_url.startswith('http') %}
 
       {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
+
   {% endblock %}
 
   {% block metadata_fields %}
@@ -46,8 +47,11 @@
 
     {% block package_metadata_author %}
       {{ form.input('author', label=_('Submitted By'), id='field-author', placeholder=_('Joe Bloggs'), value=data.author, error=errors.author, classes=['control-medium']) }}
-
       {{ form.input('author_email', label=_('Submitter Email'), id='field-author-email', placeholder=_('joe@example.com'), value=data.author_email, error=errors.author_email, classes=['control-medium']) }}
+    {% endblock %}
+
+    {% block package_metadata_allow_commenting %}
+      {{ form.select('allow_commenting', label='Allow commenting', id='field-allow-commenting', options=[{'text':'Yes', 'value': 'yes'},{'text': 'No', 'value': 'no'}], selected=(data.allow_commenting or 'yes'), error=errors.allow_commenting) }}
     {% endblock %}
   {% endblock %}
 

--- a/ckanext/showcase/templates/showcase/new_package_form.html
+++ b/ckanext/showcase/templates/showcase/new_package_form.html
@@ -51,7 +51,9 @@
     {% endblock %}
 
     {% block package_metadata_allow_commenting %}
-      {{ form.select('allow_commenting', label='Allow commenting', id='field-allow_commenting', options=[{'text':'Yes', 'value': True},{'text': 'No', 'value': False}], selected=data.allow_commenting, error=errors.allow_commenting) }}
+      {% if c.disqus_name %}
+        {{ form.select('allow_commenting', label='Allow commenting', id='field-allow_commenting', options=[{'text':'Yes', 'value': True},{'text': 'No', 'value': False}], selected=data.allow_commenting, error=errors.allow_commenting) }}
+      {% endif %}
     {% endblock %}
   {% endblock %}
 

--- a/ckanext/showcase/templates/showcase/new_package_form.html
+++ b/ckanext/showcase/templates/showcase/new_package_form.html
@@ -51,7 +51,7 @@
     {% endblock %}
 
     {% block package_metadata_allow_commenting %}
-      {{ form.select('allow_commenting', label='Allow commenting', id='field-allow-commenting', options=[{'text':'Yes', 'value': 'yes'},{'text': 'No', 'value': 'no'}], selected=(data.allow_commenting or 'yes'), error=errors.allow_commenting) }}
+      {{ form.select('allow_commenting', label='Allow commenting', id='field-allow_commenting', options=[{'text':'Yes', 'value': True},{'text': 'No', 'value': False}], selected=data.allow_commenting, error=errors.allow_commenting) }}
     {% endblock %}
   {% endblock %}
 

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -88,7 +88,7 @@
   {% endblock %}
 
   {% block disqus_comments %}
-    {% if c.disqus_name and pkg.allow_commenting %}
+    {% if h.is_disqus_enabled() and pkg.allow_commenting %}
       {{ h.disqus_comments() }}
     {% endif %}
   {% endblock %}

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -88,7 +88,9 @@
   {% endblock %}
 
   {% block disqus_comments %}
-    {{ h.disqus_comments() }}
+    {% if c.disqus_name and pkg.allow_commenting %}
+      {{ h.disqus_comments() }}
+    {% endif %}
   {% endblock %}
 {% endblock %}
 

--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -87,6 +87,9 @@
   {% block package_search_results_list %}
   {% endblock %}
 
+  {% block disqus_comments %}
+    {{ h.disqus_comments() }}
+  {% endblock %}
 {% endblock %}
 
 {% block secondary_content %}


### PR DESCRIPTION
- fixes https://github.com/okfn/ckanext-lacounts/issues/18

---

This feature is active only if there is `disqus.name` setting. So it creates a kinda weak dependency to `ckanext-disqus`. If the latter is not available this PR has no effect on the showcases.